### PR TITLE
Add optional tracking_postal_code to add_package

### DIFF
--- a/pyaftership/tracker.py
+++ b/pyaftership/tracker.py
@@ -54,7 +54,7 @@ class Tracking(object):
         return self._trackings
 
     async def add_package_tracking(self, tracking_number, title=None,
-                                   slug=None):
+                                   slug=None, tracking_postal_code=None):
         """Add tracking information."""
         headers = {
             'aftership-api-key': self.api_key,
@@ -67,6 +67,8 @@ class Tracking(object):
             data['tracking']['slug'] = slug
         if title is not None:
             data['tracking']['title'] = title
+        if tracking_postal_code is not None:
+            data['tracking']['tracking_postal_code'] = tracking_postal_code
         try:
             async with async_timeout.timeout(8, loop=self._loop):
                 await self._session.post(URL, headers=headers, json=data)


### PR DESCRIPTION
This PR adds tracking_postal_code as an optional parameter. Some slugs like "dhl-germany" require the recipient postal code to track the delivery. In case you accept the PR and push a new version, I'll prepare a PR for the home assistant component too.